### PR TITLE
Include *.tmLanguage.cache files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[co]
+*.tmLanguage.cache
 
 # Packages
 *.egg


### PR DESCRIPTION
Sublime generates .tmLanguage.cache files which should be excluded from
Git.
