### PR TITLE
Extract default settings from emmet-app.js to sublime-settings

### DIFF
--- a/Emmet.sublime-settings
+++ b/Emmet.sublime-settings
@@ -1,10 +1,9 @@
 {
 	// Copy any modified settings to `User/Emmet.sublime-settings`
 	// otherwise modifications will not survive updates.
-
 	"extensions_path": "~/emmet",
 
-	// disable completions of HTML attributes
+	// Disable completions of HTML attributes
 	// with this option disabled, you can get attribute list completions
 	// inside opening HTML tags.
 	// WARNING: with this option disabled, Tab key expander will not
@@ -15,18 +14,108 @@
 	// abbreviation expander should be disabled	 
 	"disable_tab_abbreviations_for_scopes": "",
 
-	// exit tabstop mode when enter key is pressed
-    "clear_fields_on_enter_key": true,
+	// Exit tabstop mode when enter key is pressed
+	"clear_fields_on_enter_key": true,
 
+	// Custom snippets definitions, as per https://github.com/sergeche/zen-coding/blob/v0.7.1/snippets.json
 	"snippets": {
-		// custom snippets definitions, as per https://github.com/sergeche/zen-coding/blob/v0.7.1/snippets.json
 		// "html": {
 		// 	"abbreviations": {
 		// 		"example": "<div class='example' title='Custom element example'>"
 		// 	}
 		// }
 	},
+
+	// Core preferences
 	"preferences": {
-		// custom core preferences
+		// Defines a symbol that should be placed between CSS property and
+		// value when expanding CSS abbreviations.
+		"css.valueSeparator": ": ",
+
+		// Defines a symbol that should be placed at the end of CSS property
+		// when expanding CSS abbreviations.
+		"css.propertyEnd": ";",
+
+		// Automatically generate vendor-prefixed copies of expanded CSS
+		// property. By default, Emmet will generate vendor-prefixed
+		// properties only when you put dash before abbreviation
+		// (e.g. <code>-bxsh</code>). With this option enabled, you don’t
+		// need dashes before abbreviations: Emmet will produce
+		// vendor-prefixed properties for you.
+		"css.autoInsertVendorPrefixes": true,
+
+		// Indentation before closing brace of CSS rule. Some users prefere
+		// indented closing brace of CSS rule for better readability.
+		// This preference’s value will be automatically inserted before
+		// closing brace when user adds newline in newly created CSS rule
+		// (e.g. when “Insert formatted linebreak” action will be performed
+		// in CSS file). If you’re such user, you may want to write put a value
+		// like <code>\\n\\t</code> in this preference.
+		"css.closeBraceIndentation": "\n",
+
+		// The list of properties whose values ​​must not contain units.
+		"css.unitlessProperties": "z-index, line-height, opacity, font-weight",
+
+		// A comma-separated list of vendor-prefixes for which values should
+		// be generated.
+		"css.gradient.prefixes" : "webkit, moz, o",
+
+		// Generate gradient definition for old Webkit implementations
+		"css.gradient.oldWebkit" : true,
+
+		// Do not output default direction definition in generated gradients.
+		"css.gradient.omitDefaultDirection" : true,
+
+		// Defines a symbol that should be placed between CSS property and
+		// value when expanding CSS abbreviations in Stylus dialect.
+		"stylus.valueSeparator": " ",
+
+		// Defines a symbol that should be placed at the end of CSS property
+		// when expanding CSS abbreviations in Stylus dialect.
+		"stylus.propertyEnd": "",
+
+		// Defines a symbol that should be placed at the end of CSS property
+		// when expanding CSS abbreviations in SASS dialect.
+		"sass.propertyEnd": "",
+
+		// Class name’s element separator.
+		"bem.elementSeparator" : "__", 
+
+		// Class name’s modifier separator.
+		"bem.modifierSeparator": "_", 
+
+		// Symbol for describing short “block-element” notation. Class names
+		// prefixed with this symbol will be treated as element name for parent‘s
+		// block name. Each symbol instance traverses one level up in parsed
+		// tree for block name lookup. Empty value will disable short notation.
+		"bem.shortElementPrefix": "-", 
+
+		// A definition of comment that should be placed <i>after</i> matched
+		// element when <code>comment</code> filter is applied. This definition
+		// is an ERB-style template passed to <code>_.template()</code>
+		// function (see Underscore.js docs for details). In template context,
+		// the following properties and functions are availabe:\n
+		// <ul>
+		// 	<li><code>attr(name, before, after)</code> – a function that outputs
+		// 	specified attribute value concatenated with <code>before</code>
+		// 	and <code>after</code> strings. If attribute doesn\'t exists, the
+		// 	empty string will be returned.</li>
+		// 	<li><code>node</code> – current node (instance of <code>AbbreviationNode</code>)</li>
+		// 	<li><code>name</code> – name of current tag</li>
+		// 	<li><code>padding</code> – current string padding, can be used
+		// 	for formatting</li>
+		// </ul>
+		"filter.commentAfter" : "\n<!-- /<%= attr(\"id\", \"#\") %><%= attr(\"class\", \".\") %> -->",
+
+		// A definition of comment that should be placed <i>before</i> matched
+		// element when <code>comment</code> filter is applied.
+		// For more info, read description of <code>filter.commentAfter</code>
+		// property.
+		"filter.commentBefore": "",
+
+		// A comma-separated list of attribute names that should exist in abbreviatoin
+		// where comment should be added. If you wish to add comment for
+		// every element, set this option to <code>*</code>.
+		"filter.commentTrigger": "id, class"
 	}
 }


### PR DESCRIPTION
Users of emmet plugin must know all customisable settings without code view.
My usecase - i write sass with semicolon on end of line, but emmet dont put them by default. I had decided to rewrite the emmet's sass function but find this settings.
Also change style of some comments in Emmet.sublime-settings like in general Preferences.sublime-settings.
