### PR TITLE
Encode image to data:URL : Use content type from HTTP headers.

### DIFF
--- a/emmet/emmet-app.js
+++ b/emmet/emmet-app.js
@@ -9835,7 +9835,7 @@ emmet.exec(function(require, _) {
 		var editorFile = editor.getFilePath();
 		var defaultMimeType = 'application/octet-stream';
 			
-		if (editorFile === null) {
+		if (!/^https?:\/\//.test(imgPath) && editorFile === null) {
 			throw "You should save your file before using this action";
 		}
 		
@@ -9845,7 +9845,7 @@ emmet.exec(function(require, _) {
 			throw "Can't find " + imgPath + ' file';
 		}
 		
-		file.read(realImgPath, function(err, content) {
+		file.read(realImgPath, function(err, content, ct) {
 			if (err) {
 				throw 'Unable to read ' + realImgPath + ': ' + err;
 			}
@@ -9855,7 +9855,7 @@ emmet.exec(function(require, _) {
 				throw "Can't encode file content to base64";
 			}
 			
-			b64 = 'data:' + (actionUtils.mimeTypes[String(file.getExt(realImgPath))] || defaultMimeType) +
+			b64 = 'data:' + (ct || actionUtils.mimeTypes[String(file.getExt(realImgPath))] || defaultMimeType) +
 				';base64,' + b64;
 				
 			editor.replaceContent('$0' + b64, pos, pos + imgPath.length);

--- a/emmet/file.py
+++ b/emmet/file.py
@@ -21,7 +21,7 @@ def is_url(path):
 
 def read_http(url, size=-1, mode=None):
 	response = urllib2.urlopen(url, timeout=5)
-	return response.read(size)
+	return response.read(size), response.info().gettype()
 
 def read_file(path, size=-1, mode='rb'):
 	kwargs = {}
@@ -29,7 +29,7 @@ def read_file(path, size=-1, mode='rb'):
 		kwargs['encoding'] = 'utf-8'
 
 	with open(path, mode, **kwargs) as fp:
-		return fp.read(size)
+		return fp.read(size), None
 
 class File():
 	def __init__(self):
@@ -48,7 +48,7 @@ class File():
 		"""
 
 		try:
-			content = self._read(path, size)
+			content, ct = self._read(path, size)
 
 			# return as array of character codes since PyV8 may corrupt
 			# binary data when python string is translated into JS string
@@ -60,7 +60,7 @@ class File():
 		except Exception as e:
 			return callback(str(e), None)
 
-		callback(None, content)
+		callback(None, content, ct)
 
 	def read_text(self, path, size, callback=None):
 		"""

--- a/emmet/python-wrapper.js
+++ b/emmet/python-wrapper.js
@@ -52,15 +52,15 @@ emmet.define('file', function(require, _) {
 			var params = this._parseParams(arguments);
 
 			try {
-				pyFile.read(params.path, params.size, function(err, content) {
+			    pyFile.read(params.path, params.size, function(err, content, ct) {
 					if (err) {
-						return params.callback(err, content);
+					    return params.callback(err, content, ct);
 					}
 
 					content = _.map(content || [], function(b) {
 						return String.fromCharCode(b);
 					}).join('');
-					params.callback(null, content);
+					params.callback(null, content, ct);
 				});
 			} catch(e) {
 				params.callback(e);


### PR DESCRIPTION
- Encode image to data:URL : Use content type from HTTP headers.
- Don't require file to be saved to be able to encode fully qualified URLs.
