### PR TITLE
Fixed a small bug that affects OSX users

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -45,7 +45,7 @@
     }, 
     {
         "keys": [
-            "super+shift+forward_slash"
+            "alt+shift+forward_slash"
         ], 
         "args": {
             "action": "toggle_comment"


### PR DESCRIPTION
I've changed the shortcut to something more sensible - the old one overrides default OSX shortcut which lets you search through help menu.
