### PR TITLE
Added 'label' abbreviation without the 'for' attribute for XML

### DIFF
--- a/emmet/snippets.json
+++ b/emmet/snippets.json
@@ -802,7 +802,10 @@
 	"xml": {
 		"extends": "html",
 		"profile": "xml",
-		"filters": "html"
+		"filters": "html",
+		"abbreviations": {
+			"label": "<label>"
+		}
 	},
 	
 	"xsl": {


### PR DESCRIPTION
I use the 'label' tag in XML a quite often.

The original snippet added a 'for' attribute automatically, which is meant for HTML.
I added a custom abbreviation for the 'label' tag for XML as i found it quite annoying to remove the 'for' attribute every time.
