### PR TITLE
Capitalize the html5 doctype

### DIFF
--- a/emmet/snippets.json
+++ b/emmet/snippets.json
@@ -621,7 +621,7 @@
 		"filters": "html",
 		"profile": "html",
 		"snippets": {
-			"!!!":    "<!doctype html>",
+			"!!!":    "<!DOCTYPE html>",
 			"!!!4t":  "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">",
 			"!!!4s":  "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">",
 			"!!!xt":  "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">",


### PR DESCRIPTION
Some older browsers (I think its ie<7) will complain about the doctype if it's not capitalized.

http://stackoverflow.com/a/9109157/1517919
