### PR TITLE
fix(getSyntax): fix false-positives in detecting any .js scope as .jsx

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -371,7 +371,7 @@ function pyGetSyntax() {
 		return 'xsl';
 	}
 
-	if (!/\bstring\b/.test(scope) && /\bsource\.jsx?\b/.test(scope)) {
+	if (!/\bstring\b/.test(scope) && /\bsource\..*\.?jsx\b/.test(scope)) {
 		return 'jsx';
 	}
 


### PR DESCRIPTION
An important fix for emmet breaking html classes by outputting `className` in all javascript scopes (not just jsx)

closes #565 
