### PR TITLE
Add PostCSS

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -39,7 +39,7 @@
         "command": "run_emmet_action", 
         "context": [
             {
-                "operand": "source.css, source.less, source.scss, text.xml, text.html - source", 
+                "operand": "source.css, source.less, source.scss, source.postcss, text.xml, text.html - source", 
                 "operator": "equal", 
                 "match_all": true, 
                 "key": "selector"
@@ -374,7 +374,7 @@
         "command": "expand_abbreviation_by_tab", 
         "context": [
             {
-                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
+                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.postcss, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
                 "operator": "equal", 
                 "match_all": true, 
                 "key": "selector"
@@ -420,7 +420,7 @@
         "command": "expand_abbreviation_by_tab", 
         "context": [
             {
-                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
+                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.postcss, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
                 "operator": "equal", 
                 "match_all": true, 
                 "key": "selector"

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -39,7 +39,7 @@
         "command": "run_emmet_action", 
         "context": [
             {
-                "operand": "source.css, source.less, source.scss, text.xml, text.html - source", 
+                "operand": "source.css, source.less, source.scss, source.postcss, text.xml, text.html - source", 
                 "operator": "equal", 
                 "match_all": true, 
                 "key": "selector"
@@ -374,7 +374,7 @@
         "command": "expand_abbreviation_by_tab", 
         "context": [
             {
-                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
+                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.postcss, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
                 "operator": "equal", 
                 "match_all": true, 
                 "key": "selector"
@@ -420,7 +420,7 @@
         "command": "expand_abbreviation_by_tab", 
         "context": [
             {
-                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
+                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.postcss, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
                 "operator": "equal", 
                 "match_all": true, 
                 "key": "selector"

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -39,7 +39,7 @@
         "command": "run_emmet_action", 
         "context": [
             {
-                "operand": "source.css, source.less, source.scss, text.xml, text.html - source", 
+                "operand": "source.css, source.less, source.scss, source.postcss, text.xml, text.html - source", 
                 "operator": "equal", 
                 "match_all": true, 
                 "key": "selector"
@@ -374,7 +374,7 @@
         "command": "expand_abbreviation_by_tab", 
         "context": [
             {
-                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
+                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.postcss, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
                 "operator": "equal", 
                 "match_all": true, 
                 "key": "selector"
@@ -420,7 +420,7 @@
         "command": "expand_abbreviation_by_tab", 
         "context": [
             {
-                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
+                "operand": "source.css, source.sass, source.less, source.scss, source.stylus, source.postcss, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string", 
                 "operator": "equal", 
                 "match_all": true, 
                 "key": "selector"

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Not that if you disabled any action like so and you’re create your own keyboar
 
 ## How to expand abbreviations with Tab in other syntaxes
 
-Emmet expands abbreviations in limited syntaxes only: HTML, CSS, LESS, SCSS and Stylus. The reason to restrict Tab handler to a limited syntax list is because it breaks native Sublime Text snippets. 
+Emmet expands abbreviations in limited syntaxes only: HTML, CSS, LESS, SCSS, Stylus and PostCSS. The reason to restrict Tab handler to a limited syntax list is because it breaks native Sublime Text snippets. 
 
 If you want to abbreviation with Tab in other syntaxes (for example, JSX, HAML etc.) you have to tweak your [keyboard shorcuts settings](http://sublime-text-unofficial-documentation.readthedocs.org/en/sublime-text-2/reference/key_bindings.html): add `expand_abbreviation_by_tab` command for `tab` key for required syntax *scope selectors*. To get current syntax scope selector, press <kbd>⇧⌃P</kbd> (OSX) or <kbd>Ctrl+Alt+Shift+P</kbd>, it will be displayed in editor status bar.
 
@@ -144,7 +144,7 @@ Go to `Preferences` > `Key Bindings — User` and insert the following JSON snip
 
 Emmet plugin allows you to expand abbreviations with <kbd>Tab</kbd> key, just like regular snippets. On the other hand, due to dynamic nature and extensive syntax, sometimes you may get unexpected results. This section describes how Tab handler works and how you can fine-tune it.
 
-By default, Tab handler works in a limited _syntax scopes_: HTML, XML, HAML, CSS, SASS/SCSS, LESS and _strings in programming languages_ (like JavaScript, Python, Ruby etc.). It means:
+By default, Tab handler works in a limited _syntax scopes_: HTML, XML, HAML, CSS, SASS/SCSS, LESS, PostCSS and _strings in programming languages_ (like JavaScript, Python, Ruby etc.). It means:
 
 * You have to switch your document to one of the syntaxes listed above to expand abbreviations by Tab key.
 * With <kbd>Ctrl-E</kbd> shortcut, you can expand abbreviations everywhere, its scope is not limited.

--- a/editor.js
+++ b/editor.js
@@ -379,10 +379,14 @@ function pyGetSyntax() {
 
 	if (!/\bstring\b/.test(scope) && /\bsource\.([\w\-]+)/.test(scope) && resources.hasSyntax(RegExp.$1)) {
 		syntax = RegExp.$1;
-	} else if (/\b(less|scss|sass|css|stylus)\b/.test(scope)) {
-		// detect CSS-like syntaxes independently, 
+	} else if (/\b(less|scss|sass|css|stylus|postcss)\b/.test(scope)) {
+		// detect CSS-like syntaxes independently,
 		// since it may cause collisions with some highlighters
 		syntax = RegExp.$1;
+
+		if (syntax === 'postcss') {
+			syntax = 'css';
+		}
 	} else if (/\b(html|xml|haml|slim|jade)\b/.test(scope)) {
 		syntax = RegExp.$1;
 	}

--- a/misc/generate-keymap.py
+++ b/misc/generate-keymap.py
@@ -2,7 +2,7 @@ import os.path
 import json
 import copy
 
-TAB_HANDLER_SCOPES = "source.css, source.sass, source.less, source.scss, source.stylus, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string"
+TAB_HANDLER_SCOPES = "source.css, source.sass, source.less, source.scss, source.stylus, source.postcss, source.jade, text.jade, text.slim, text.xml, text.html - source, text.haml, text.scala.html, source string"
 
 keymap = {
 	"expand_abbreviation": "ctrl+e",
@@ -15,8 +15,8 @@ keymap = {
 		"mac": "alt+shift+forward_slash",
 		"pc": "ctrl+shift+forward_slash",
 		"context": [{
-			"key": "selector", 
-			"operand": "source.css, source.less, source.scss, text.xml, text.html - source",
+			"key": "selector",
+			"operand": "source.css, source.less, source.scss, source.postcss, text.xml, text.html - source",
 			"operator": "equal"
 		}]
 	},


### PR DESCRIPTION
I want to add PostCSS support so I can use Emmet in Sublime Text with [PostCSS syntax highlighting](https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS). This syntax file using `scss` scope for now, but I want to switch it to `postcss`. I haven't switched it yet because users of PostCSS syntax haven't possibility to use Emmet. So I want add `postcss` scope support to Emmet first, and then switch syntax file to it.

I haven't change `snippets.json` and `emmet-app.js` as I understand they came from [emmetio/emmet](https://github.com/emmetio/emmet) repository. So I've made a PR to that repository: https://github.com/emmetio/emmet/pull/411.