### PR TITLE
Add TypeScriptReact JSX expanding support

### DIFF
--- a/emmet/snippets.json
+++ b/emmet/snippets.json
@@ -930,6 +930,10 @@
 		"profile": "xml"
 	},
 
+	"tsx": {
+		"extends": "jsx"
+	},
+
 	"slim": {
 		"filters": "slim",
 		"extends": "html",


### PR DESCRIPTION
# Problem
At the moment it need to add some user settings to emmet after install it to proper jsx expanding in TypeScriptReact syntax, but it can be done out of the box, this PR do that :)

## Without jsx extending:
![without](https://user-images.githubusercontent.com/13422799/47200271-2121bf80-d37e-11e8-8f11-368a4c5d08c0.gif)

## With jsx extending:
![with](https://user-images.githubusercontent.com/13422799/47200285-2e3eae80-d37e-11e8-934c-32f76498c48c.gif)
