### PR TITLE
Use new Sublime Text 3 setting workflow

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -16,70 +16,21 @@
                         "children":
                         [
                             {
-                                "command": "open_file", "args":
-                                {
-                                    "file": "${packages}/Emmet/Emmet.sublime-settings"
-                                },
-                                "caption": "Settings – Default"
-                            },
-                            {
-                                "command": "open_file", "args":
-                                {
-                                    "file": "${packages}/User/Emmet.sublime-settings"
-                                },
-                                "caption": "Settings – User"
-                            },
-                            { "caption": "-" },
-                            { "caption": "-" },
-                            {
-                                "command": "open_file",
+                                "caption": "Settings",
+                                "command": "edit_settings",
                                 "args": {
-                                    "file": "${packages}/Emmet/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – Default"
+                                    "base_file": "${packages}/Emmet/Emmet.sublime-settings",
+                                    "default": "${packages}/User/Emmet.sublime-settings"
+                                }
                             },
                             {
-                                "command": "open_file",
+                                "caption": "Key Bindings",
+                                "command": "edit_settings",
                                 "args": {
-                                    "file": "${packages}/Emmet/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/Emmet/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            { "caption": "-" }
+                                    "base_file": "${packages}/Emmet/Default ($platform).sublime-keymap",
+                                    "default": "${packages}/User/Default ($platform).sublime-keymap"
+                                }
+                            }
                         ]
                     }
                 ]

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Emmet expands abbreviations in limited syntaxes only: HTML, CSS, LESS, SCSS, Sty
 
 If you want to abbreviation with Tab in other syntaxes (for example, JSX, HAML etc.) you have to tweak your [keyboard shorcuts settings](http://sublime-text-unofficial-documentation.readthedocs.org/en/sublime-text-2/reference/key_bindings.html): add `expand_abbreviation_by_tab` command for `tab` key for required syntax *scope selectors*. To get current syntax scope selector, press <kbd>⇧⌃P</kbd> (OSX) or <kbd>Ctrl+Alt+Shift+P</kbd>, it will be displayed in editor status bar.
 
-Go to `Preferences` > `Key Bindings — User` and insert the following JSON snippet with properly configured scope selector instead of `SCOPE_SELECTOR` token:
+Go to `Preferences` > `Key Bindings` and insert the following JSON snippet with properly configured scope selector instead of `SCOPE_SELECTOR` token:
 
 ```js
 {


### PR DESCRIPTION
Use side-by-side settings and keybindings introduced in Sublime Text 3 Build 3124 (22 September 2016). It works exactly the same as Sublime Text settings: opens two columns tab, first column — default settings, second column — user settings.

Before:

<img width="443" alt="screenshot 2018-12-23 at 12 53 34" src="https://user-images.githubusercontent.com/654597/50383483-bb6eee00-06b4-11e9-8d9d-2b3cd3b549cd.png">

After:

<img width="393" alt="screenshot 2018-12-23 at 12 52 34" src="https://user-images.githubusercontent.com/654597/50383485-c164cf00-06b4-11e9-9235-6b9e788258f9.png">

This is breaking backward compatibility with Sublime Text 2, which is ok, in my opinion, having in mind Sublime Text 3 was released almost 6 years ago.